### PR TITLE
fix: 修复导入xlsx的无法智能分配章节

### DIFF
--- a/src/pages/dict/components/WordDictDetail.vue
+++ b/src/pages/dict/components/WordDictDetail.vue
@@ -275,9 +275,10 @@ function toChapterWordList() {
   )
 }
 
-//同步到我的词典列表
+//同步到我的词典列表，更新词典单词总数
 function syncEditDict2MyDictList() {
-  syncMyDictList(runtimeStore.editDict)
+  runtimeStore.editDict.length = runtimeStore.editDict.words.length;
+  syncMyDictList(runtimeStore.editDict);
 }
 
 
@@ -486,9 +487,9 @@ function exportData(type: string) {
 }
 
 function importData(e: any) {
-  let file = e.target.files[0]
-  if (!file) return
-  // no()
+  let file = e.target.files[0];
+  if (!file) return;
+
   let reader = new FileReader();
   reader.onload = function (e) {
     let data = e.target.result;
@@ -505,31 +506,35 @@ function importData(e: any) {
             usphone: String(v['音标①'] ?? ''),
             ukphone: String(v['音标②'] ?? ''),
             trans: String(v['释义(一行一个释义)'] ?? '').split('\n')
-          }
-          return word
+          };
+          return word;
         }
-      }).filter(v => v)
+      }).filter(v => v);
 
       checkRepeatWord(words, residueWordList, noRepeatWords => {
-            residueWordList = residueWordList.concat(noRepeatWords)
-            syncEditDict2MyDictList()
-            setTimeout(residueWordListRef?.scrollToBottom, 100)
+            residueWordList = residueWordList.concat(noRepeatWords);
+            // 同步到editDict中的words和originWords
+            runtimeStore.editDict.words = runtimeStore.editDict.words.concat(noRepeatWords);
+            runtimeStore.editDict.originWords = runtimeStore.editDict.originWords.concat(noRepeatWords);
+            syncEditDict2MyDictList();
+            setTimeout(residueWordListRef?.scrollToBottom, 100);
           },
           repeatWords => {
             repeatWords.map(v => {
-              residueWordList[v.index] = v
-              delete residueWordList[v.index].index
-            })
-            syncEditDict2MyDictList()
-            setTimeout(residueWordListRef?.scrollToBottom, 100)
+              residueWordList[v.index] = v;
+              delete residueWordList[v.index].index;
+            });
+            syncEditDict2MyDictList();
+            setTimeout(residueWordListRef?.scrollToBottom, 100);
           },
-          () => ElMessage.success('导入成功！'))
+          () => ElMessage.success('导入成功！'));
     } else {
-      ElMessage.warning('导入失败！原因：没有数据')
+      ElMessage.warning('导入失败！原因：没有数据');
     }
   };
   reader.readAsBinaryString(file);
 }
+
 
 function editDict() {
   isEditDict = true


### PR DESCRIPTION
1、描述
导入xlsx文件后总词汇一直显示为0，无法进行智能分配章节
测试文件：[2021新东方四级乱序合并版.xlsx](https://github.com/user-attachments/files/16261399/2021.xlsx)
2、截图
![QQ_1721199316118](https://github.com/user-attachments/assets/a830f48a-811b-49b3-9688-9cf2c1172832)


可以获取到导入的所有单词，但是无法智能分配章节
![image](https://github.com/user-attachments/assets/741e126a-19b2-4778-b0eb-65b55a9554e3)
